### PR TITLE
Use clause can be aliased

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,4 +7,9 @@
       "Krlove\\CodeGenerator\\": "src/"
     }
   }
+  "extra": {
+      "branch-alias": {
+          "dev-master": "1.0.x-dev"
+      }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "psr-4": {
       "Krlove\\CodeGenerator\\": "src/"
     }
-  }
+  },
   "extra": {
       "branch-alias": {
           "dev-master": "1.0.x-dev"

--- a/src/Model/ArgumentModel.php
+++ b/src/Model/ArgumentModel.php
@@ -29,7 +29,7 @@ class ArgumentModel extends RenderableModel
      * ArgumentModel constructor.
      * @param string $name
      * @param string|null $type
-     * @param mixed|null $default
+     * @param mixed|null $default used "as is"
      */
     public function __construct($name, $type = null, $default = null)
     {
@@ -43,11 +43,12 @@ class ArgumentModel extends RenderableModel
      */
     public function toLines()
     {
-        if ($this->type !== null) {
-            return $this->type . ' $' . $this->name;
-        } else {
+        if ($this->default !== null) {
+            return ltrim($this->type?:'' . ' $' . $this->name. ' = ' .$this->default);
+         } else {
             return '$' . $this->name;
-        }
+            return ltrim($this->type?:'' . ' $' . $this->name);
+         }
     }
 
     /**

--- a/src/Model/UseClassModel.php
+++ b/src/Model/UseClassModel.php
@@ -33,8 +33,8 @@ class UseClassModel extends RenderableModel
      * {@inheritDoc}
      */
     public function toLines()
-    {   
-        if (is_null($this->alias) {
+    {
+        if (is_null($this->alias)) {
             return sprintf('use %s;', $this->name);
         }
         else {
@@ -49,7 +49,7 @@ class UseClassModel extends RenderableModel
     {
         return $this->name;
     }
-            
+
     /**
      * @return string
      */

--- a/src/Model/UseClassModel.php
+++ b/src/Model/UseClassModel.php
@@ -14,22 +14,32 @@ class UseClassModel extends RenderableModel
      * @var string
      */
     protected $name;
+    /**
+     * @var string
+     */
+    protected $alias=null;
 
     /**
      * PHPClassUse constructor.
      * @param string $name
      */
-    public function __construct($name)
+    public function __construct($name,$alias=null)
     {
         $this->name = $name;
+        if ($alias) $this->alias=$alias;
     }
 
     /**
      * {@inheritDoc}
      */
     public function toLines()
-    {
-        return sprintf('use %s;', $this->name);
+    {   
+        if (is_null($this->alias) {
+            return sprintf('use %s;', $this->name);
+        }
+        else {
+            return sprintf('use %s as %s;', $this->name,$this->alias);
+        }
     }
 
     /**
@@ -38,6 +48,14 @@ class UseClassModel extends RenderableModel
     public function getName()
     {
         return $this->name;
+    }
+            
+    /**
+     * @return string
+     */
+    public function getAlias()
+    {
+        return $this->alias;
     }
 
     /**
@@ -48,6 +66,18 @@ class UseClassModel extends RenderableModel
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @param string $alias
+     *
+     * @return $this
+     */
+    public function setAlias($alias)
+    {
+        $this->alias = $alias;
 
         return $this;
     }


### PR DESCRIPTION
UseClassModel constructor now accepts an optional alias parameter
Example
```                
$extClass = new ClassModel();
// Use App\Models\Auto\User as GeneratedClass
$extClass->addUses(new UseClassModel('App\\Models\\Auto\\User','GeneratedClass"));`
```
Generates this use clause:
`use App\Models\Auto\User as GeneratedClass;`